### PR TITLE
Pluralize when using resources mapping

### DIFF
--- a/src/RestfulRouting.Tests/Integration/Resources/ResourcesSpec.cs
+++ b/src/RestfulRouting.Tests/Integration/Resources/ResourcesSpec.cs
@@ -155,7 +155,7 @@ namespace RestfulRouting.Tests.Integration
 
 		Because of = () => new BlogArea().RegisterRoutes(routes);
 
-		It should_map_blog_admin_index = () => "~/blogadmin/1/blogs".WithMethod(HttpVerbs.Get).ShouldMapTo<BlogsController>(x => x.Index());
+		It should_map_blog_admin_index = () => "~/blogadmins/1/blogs".WithMethod(HttpVerbs.Get).ShouldMapTo<BlogsController>(x => x.Index());
 	}
 
     public class when_mapping_nested_resources : base_context

--- a/src/RestfulRouting/Mappings/ResourcesMapping.cs
+++ b/src/RestfulRouting/Mappings/ResourcesMapping.cs
@@ -16,6 +16,8 @@ namespace RestfulRouting.Mappings
 
 			ResourceName = ControllerName<TController>();
 
+			MappedName = Inflector.Pluralize(ResourceName);
+
 			resourcesMapper.SetResourceAs(ResourceName);
 
 			_resourcesMapper = resourcesMapper;


### PR DESCRIPTION
I have made a change that will pluralize the resource name when using the `ResourcesMapping`. I would like any opinions on this as it will break URLs in the case people use a singular term with a plural mapping (`PersonController` will be "/people" rather than "/person").
