### PR TITLE
Specifying Only Actions Affects the Order of Route Registration

### DIFF
--- a/src/RestfulRouting.Spec/Mappers/ResourcesMapperBaseSpec.cs
+++ b/src/RestfulRouting.Spec/Mappers/ResourcesMapperBaseSpec.cs
@@ -191,4 +191,17 @@ namespace RestfulRouting.Spec.Mappers
         It should_be_a_resources_method_exception = () => Exception.ShouldBeOfType<InvalidRestfulMethodException>();
         It should_have_a_descriptive_message = () => Exception.Message.ShouldBe("the controller 'posts' only has methods index, create, new, edit, show, update, destroy.");
     }
+
+	public class when_specifying_only_actions_in_a_random_order : resources_mapper_base
+	{
+		Because of = () => 
+			tester.Only("create", "show", "edit");
+
+		It should_keep_the_order_for_mvc_to_pick_correct_route_and_not_the_random_order_specified = () =>
+		{
+			tester.IncludedActions().Keys.ElementAt(0).ShouldEqual("create");
+			tester.IncludedActions().Keys.ElementAt(1).ShouldEqual("edit");
+			tester.IncludedActions().Keys.ElementAt(2).ShouldEqual("show");
+		};
+	}
 }

--- a/src/RestfulRouting/Exceptions/InvalidRestfulMethodException.cs
+++ b/src/RestfulRouting/Exceptions/InvalidRestfulMethodException.cs
@@ -3,8 +3,8 @@
 namespace RestfulRouting.Exceptions
 {
     public class InvalidRestfulMethodException : Exception {
-        public InvalidRestfulMethodException(string controllerName, string[] actions, Exception ex)
-            :base(string.Format("the controller '{0}' only has methods {1}.",  controllerName, string.Join(", ", actions)), ex)
+        public InvalidRestfulMethodException(string controllerName, string[] actions)
+            :base(string.Format("the controller '{0}' only has methods {1}.",  controllerName, string.Join(", ", actions)))
         {}
     }
 }

--- a/src/RestfulRouting/Mappers/ResourcesMapperBase.cs
+++ b/src/RestfulRouting/Mappers/ResourcesMapperBase.cs
@@ -51,22 +51,14 @@ namespace RestfulRouting.Mappers
 
         public void Only(params string[] actions)
         {
-            try
-            {
-                var onlyIncludedActions = new Dictionary<string, Func<Route>>(StringComparer.OrdinalIgnoreCase);
-                foreach (var action in actions)
-                {
-                    onlyIncludedActions.Add(action, IncludedActions[action]);
-                }
-                IncludedActions = onlyIncludedActions;
-            }
-            catch (KeyNotFoundException exception)
-            {
-                throw new InvalidRestfulMethodException(GetControllerName<TController>(), IncludedActions.Keys.ToArray(), exception );
-            }
+        	if (actions.Any(action => !IncludedActions.ContainsKey(action)))
+        		throw new InvalidRestfulMethodException(GetControllerName<TController>(), IncludedActions.Keys.ToArray());
+
+        	IncludedActions = IncludedActions.Where(a => actions.Contains(a.Key, StringComparer.OrdinalIgnoreCase))
+															.ToDictionary(k => k.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
         }
 
-        public void WithFormatRoutes()
+    	public void WithFormatRoutes()
         {
             GenerateFormatRoutes = true;
         }


### PR DESCRIPTION
The order of the Only actions is the order the routes get registered and not the original order in IncludedActions.

So
map.Resources<ListController>(m => m.Only("show", "edit", "new"));
meant that /list/edit was being routed to the show action as /list/{id} where 'edit' was the id, as mvc matched this one first.

Hope that makes sense. The pull request ensures the IncludedActions order is maintained. Specs included :)
