### PR TITLE
adding the ability to re-route the standard resource member actions

### DIFF
--- a/src/RestfulRouting.Spec/Mappers/ResourceMapperSpec.cs
+++ b/src/RestfulRouting.Spec/Mappers/ResourceMapperSpec.cs
@@ -89,6 +89,45 @@ namespace RestfulRouting.Spec.Mappers
         Behaves_like<SessionsResource> a_sessions_resource;
     }
 
+    public class mapping_resource_with_reroute_overrides : base_context
+    {
+        static ResourceMapper<SessionsController> _mapper;
+
+        Establish context = () =>
+            {
+                _mapper = new ResourceMapper<SessionsController>();
+                _mapper.ReRoute(c => c.New = "signup");
+                _mapper.ReRoute(c => c.Show = "{resourceName}/something/else");
+                _mapper.ReRoute(c => c.Edit = "{resourceName}/fancy/{editName}");
+            };
+
+        Because of = () => _mapper.RegisterRoutes(routes);
+
+        It should_map_get_show = () => "~/session/something/else".WithMethod(HttpVerbs.Get).ShouldMapTo<SessionsController>(x => x.Show()).WithName("session");
+
+        It should_map_get_new = () => "~/signup".WithMethod(HttpVerbs.Get).ShouldMapTo<SessionsController>(x => x.New()).WithName("new_session");
+
+        It should_map_post_create = () => "~/session".WithMethod(HttpVerbs.Post).ShouldMapTo<SessionsController>(x => x.Create());
+
+        It should_map_get_edit = () => "~/session/fancy/edit".WithMethod(HttpVerbs.Get).ShouldMapTo<SessionsController>(x => x.Edit()).WithName("edit_session");
+
+        It should_map_put_update = () => "~/session".WithMethod(HttpVerbs.Put).ShouldMapTo<SessionsController>(x => x.Update());
+
+        It should_map_delete_destroy = () => "~/session".WithMethod(HttpVerbs.Delete).ShouldMapTo<SessionsController>(x => x.Destroy());
+
+        It should_generate_show;// TODO - this fails: = () => OutBoundUrl.Of<SessionsController>(x => x.Show()).ShouldMapToUrl("/session/something/else");
+
+        It should_generate_new = () => OutBoundUrl.Of<SessionsController>(x => x.New()).ShouldMapToUrl("/signup");
+
+        It should_generate_create = () => OutBoundUrl.Of<SessionsController>(x => x.Create()).ShouldMapToUrl("/session");
+
+        It should_generate_edit;// TODO - this fails: = () => OutBoundUrl.Of<SessionsController>(x => x.Edit()).ShouldMapToUrl("/session/fancy/edit");
+
+        It should_generate_update = () => OutBoundUrl.Of<SessionsController>(x => x.Update()).ShouldMapToUrl("/session");
+
+        It should_generate_destroy = () => OutBoundUrl.Of<SessionsController>(x => x.Destroy()).ShouldMapToUrl("/session");
+    }
+
     public class mapping_resource_with_member_route : base_context
     {
         Because of = () => new ResourceMapper<SessionsController>(map => map.Member(x => x.Get("hello"))).RegisterRoutes(routes);

--- a/src/RestfulRouting/Mappers/ResourceMapper.cs
+++ b/src/RestfulRouting/Mappers/ResourceMapper.cs
@@ -22,18 +22,38 @@ namespace RestfulRouting.Mappers
             As(SingularResourceName);
             IncludedActions = new Dictionary<string, Func<Route>>(StringComparer.OrdinalIgnoreCase)
                                   {
-                                      {Names.ShowName, () => GenerateNamedRoute(JoinResources(ResourceName), ResourcePath, ControllerName, Names.ShowName, new[] { "GET" })},
-                                      {Names.UpdateName, () => GenerateRoute(ResourcePath, ControllerName, Names.UpdateName, new[] { "PUT" })},
-                                      {Names.NewName, () => GenerateNamedRoute("new_" + JoinResources(ResourceName), ResourcePath + "/" + (RouteSet.LowercaseUrls ? Names.NewName.ToLowerInvariant() : Names.NewName), ControllerName, Names.NewName, new[] { "GET" })},
-                                      {Names.EditName, () => GenerateNamedRoute("edit_" + JoinResources(ResourceName), ResourcePath + "/" + (RouteSet.LowercaseUrls ? Names.EditName.ToLowerInvariant() : Names.EditName), ControllerName, Names.EditName, new[] { "GET" })},
-                                      {Names.DestroyName, () => GenerateRoute(ResourcePath, ControllerName, Names.DestroyName, new[] { "DELETE" })},
-                                      {Names.CreateName, () => GenerateRoute(ResourcePath, ControllerName, Names.CreateName, new[] { "POST" })}
+                                      {Names.ShowName, () => GenerateNamedRoute(JoinResources(ResourceName), BuildPathFor(Paths.Show), ControllerName, Names.ShowName, new[] { "GET" })},
+                                      {Names.UpdateName, () => GenerateRoute(BuildPathFor(Paths.Update), ControllerName, Names.UpdateName, new[] { "PUT" })},
+                                      {Names.NewName, () => GenerateNamedRoute("new_" + JoinResources(ResourceName), BuildPathFor(Paths.New), ControllerName, Names.NewName, new[] { "GET" })},
+                                      {Names.EditName, () => GenerateNamedRoute("edit_" + JoinResources(ResourceName), BuildPathFor(Paths.Edit), ControllerName, Names.EditName, new[] { "GET" })},
+                                      {Names.DestroyName, () => GenerateRoute(BuildPathFor(Paths.Destroy), ControllerName, Names.DestroyName, new[] { "DELETE" })},
+                                      {Names.CreateName, () => GenerateRoute(BuildPathFor(Paths.Create), ControllerName, Names.CreateName, new[] { "POST" })}
                                   };
             if (RouteSet.MapDelete)
             {
-                IncludedActions.Add(Names.DeleteName, () => GenerateNamedRoute("delete_" + JoinResources(ResourceName), ResourcePath + "/" + (RouteSet.LowercaseUrls ? Names.DeleteName.ToLowerInvariant() : Names.DeleteName), ControllerName, Names.DeleteName, new[] { "GET" }));
+                IncludedActions.Add(Names.DeleteName, () => GenerateNamedRoute("delete_" + JoinResources(ResourceName),BuildPathFor(Paths.Delete), ControllerName, Names.DeleteName, new[] { "GET" }));
             }
             _subMapper = subMapper;
+        }
+
+        private string BuildPathFor(string path)
+        {
+            return path.Replace("{resourcePath}", ResourcePath)
+                        .Replace("{indexName}", ProperCaseUrl(Names.IndexName))
+                        .Replace("{showName}", ProperCaseUrl(Names.ShowName))
+                        .Replace("{newName}", ProperCaseUrl(Names.NewName))
+                        .Replace("{createName}", ProperCaseUrl(Names.CreateName))
+                        .Replace("{editName}", ProperCaseUrl(Names.EditName))
+                        .Replace("{updateName}", ProperCaseUrl(Names.UpdateName))
+                        .Replace("{deleteName}", ProperCaseUrl(Names.DeleteName))
+                        .Replace("{destroyName}", ProperCaseUrl(Names.DestroyName));
+        }
+
+        private string ProperCaseUrl(string url)
+        {
+            return RouteSet.LowercaseUrls
+                       ? url.ToLowerInvariant()
+                       : url;
         }
 
         public void Member(Action<AdditionalAction> action)
@@ -80,5 +100,41 @@ namespace RestfulRouting.Mappers
                 RegisterNested(routeCollection, mapper => mapper.SetParentResources(ResourcePaths));
             }
         }
+    }
+
+    public class RoutePaths
+    {
+        public RoutePaths()
+        {
+            InitializeDefaults();
+        }
+
+        private void InitializeDefaults()
+        {
+            Index = "{resourcePath}/{indexName}";
+            Show = "{resourcePath}";
+            New = "{resourcePath}/{newName}";
+            Create = "{resourcePath}";
+            Edit = "{resourcePath}/{editName}";
+            Update = "{resourcePath}";
+            Delete = "{resourcePath}/deleteName";
+            Destroy = "{resourcePath}";
+        }
+
+        public string Index { get; set; }
+
+        public string Show { get; set; }
+
+        public string New { get; set; }
+
+        public string Create { get; set; }
+
+        public string Edit { get; set; }
+
+        public string Update { get; set; }
+
+        public string Delete { get; set; }
+
+        public string Destroy { get; set; }
     }
 }

--- a/src/RestfulRouting/Mappers/ResourcesMapperBase.cs
+++ b/src/RestfulRouting/Mappers/ResourcesMapperBase.cs
@@ -14,6 +14,7 @@ namespace RestfulRouting.Mappers
         void Only(params string[] actions);
         void WithFormatRoutes();
         void PathNames(Action<RouteNames> action);
+        void ReRoute(Action<RoutePaths> action);
     }
 
     public class ResourcesMapperBase<TController> : Mapper, IResourcesMapperBase where TController : Controller
@@ -22,6 +23,7 @@ namespace RestfulRouting.Mappers
         protected string ResourcePath;
         protected string ControllerName;
         protected RouteNames Names = new RouteNames();
+        protected RoutePaths Paths = new RoutePaths();
         protected Dictionary<string, Func<Route>> IncludedActions;
         protected bool GenerateFormatRoutes;
         protected string SingularResourceName;
@@ -66,6 +68,11 @@ namespace RestfulRouting.Mappers
         public void PathNames(Action<RouteNames> action)
         {
             action(Names);
+        }
+
+        public void ReRoute(Action<RoutePaths> action)
+        {
+            action(Paths);
         }
 
         private void CalculatePath()


### PR DESCRIPTION
I love how this library guides me naturally towards a restful way of thinking.

That said, there are some endpoints that I constantly want to re-route in favor of more human-readable and commonly discoverable urls:

<table>
<tr><th>method</th><th>route</th><th>controller#action</th></tr>
<tr><td>GET</td><td>~/signup</td><td>account#new</td></tr>
<tr><td>GET</td><td>~/login</td><td>session#new</td></tr>
<tr><td>POST</td><td>~/login</td><td>session#create</td></tr>
</table>


This branch includes my attempt to refactor the path part of the ResourceMapper<T> and expose overrides that support this use case:

``` csharp
public class mapping_resource_with_reroute_overrides : base_context
{
    static ResourceMapper<SessionsController> _mapper;

    Establish context = () =>
    {
        _mapper = new ResourceMapper<SessionsController>();
        _mapper.ReRoute(c => c.New = "signup");
    };

    Because of = () => _mapper.RegisterRoutes(routes);

    It should_map_get_new = () => "~/signup".WithMethod(HttpVerbs.Get).ShouldMapTo<SessionsController>(x => x.New()).WithName("new_session");
}
```

Feedback is welcome, as is the decision whether or not this change is in keeping with the philosophy of the project.
